### PR TITLE
Restore `curl` as an installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Assuming all Pearl dependencies are properly installed in the system, to install
 run the following:
 ```sh
 wget https://raw.githubusercontent.com/pearl-core/installer/master/install.sh
+# or
+curl -LO  https://raw.githubusercontent.com/pearl-core/installer/master/install.sh
 bash install.sh
 ```
 
@@ -221,6 +223,8 @@ Once all Pearl dependencies are properly installed in the system, to install Pea
 run the following:
 ```sh
 wget https://raw.githubusercontent.com/pearl-core/installer/master/install.sh
+# or
+curl -LO  https://raw.githubusercontent.com/pearl-core/installer/master/install.sh
 bash install.sh
 ```
 


### PR DESCRIPTION
- `curl` was replaced by `wget` in [commit:bd80fbb](https://github.com/go2null/pearl/commit/bd80fbbefad32ca26e5598556716f98de83f3459) in response to pull request #44.
- This commit restores `curl` as installation example for systems without `wget`.